### PR TITLE
POM updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,13 @@
     </repository>
   </repositories>
 
+  <distributionManagement>
+    <repository>
+      <id>spartan</id>
+      <url>scpexe://ec2.spartansoftwareinc.com/srv/maven_repository</url>
+    </repository>
+  </distributionManagement>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -107,5 +114,12 @@
         </configuration>
       </plugin>
     </plugins>
+
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh-external</artifactId>
+      </extension>
+    </extensions>
   </build>
 </project>


### PR DESCRIPTION
- Took the .ant off the groupId, as it seems redundant and ending in .okapi seems consistent with how Andrae does it.
- Added Spartan repository for deployment.  Obviously, nobody other than Spartan will be able to use this, but I don't see any harm in putting it in the POM for us.
